### PR TITLE
Feature/same name file protection

### DIFF
--- a/core/include/parser.h
+++ b/core/include/parser.h
@@ -12,6 +12,7 @@ extern std::string shared_directory;
 extern std::string single_file;
 extern bool recursive_mode;
 extern std::string redirect_url;
+extern bool override_mode;
 
 void parse_arguments(int argc, char** argv);
 

--- a/core/source/parser.cpp
+++ b/core/source/parser.cpp
@@ -10,6 +10,7 @@ std::string shared_directory = ".";
 std::string single_file = "";
 bool recursive_mode = false;
 std::string redirect_url = "";
+bool override_mode = false;
 
 void parse_arguments(int argc, char** argv) {
     for (int i = 1; i < argc; i++) {
@@ -24,6 +25,8 @@ void parse_arguments(int argc, char** argv) {
             allow_upload = false;
         } else if (arg == "-u" || arg == "--upload") {
             allow_download = false;
+        }else if (arg == "-o" || arg == "--override") {
+            override_mode = true;
         } else if ((arg == "-D" || arg == "--dir") && i + 1 < argc) {
             shared_directory = argv[++i];
         } else if ((arg == "-f" || arg == "--single-file") && i + 1 < argc) {

--- a/core/source/routes/upload.cpp
+++ b/core/source/routes/upload.cpp
@@ -1,5 +1,7 @@
 #include "../../include/routes.h"
 #include "../../include/parser.h"
+#include "../../include/utils.h"
+#include <sstream>
 
 void upload_file(const httplib::Request& req, httplib::Response& res) {
     if (!allow_upload) {
@@ -19,6 +21,12 @@ void upload_file(const httplib::Request& req, httplib::Response& res) {
     }
 
     filename += file.filename;
+
+    int identificator = 0;
+    while(validate_file(filename)) {
+        std::ostringstream oss;
+        oss << filename << " (" << identificator++ << ")";
+    }
 
     std::ofstream ofs(filename, std::ios::binary);
     ofs.write(file.content.data(), file.content.size());

--- a/core/source/routes/upload.cpp
+++ b/core/source/routes/upload.cpp
@@ -20,12 +20,46 @@ void upload_file(const httplib::Request& req, httplib::Response& res) {
         std::cout << filename << std::endl;
     }
 
-    filename += file.filename;
+    if(!override_mode) {
 
-    int identificator = 0;
-    while(validate_file(filename)) {
+        filename += file.filename;
+
+        std::cout << filename << " " << std::endl;
+
+        int identificator = 0;
         std::ostringstream oss;
-        oss << filename << " (" << identificator++ << ")";
+
+        std::size_t last_dir_pos = filename.find_last_of("/");
+        std::size_t last_dot     = filename.find_last_of(".");
+        std::string extension    = "";
+
+        bool applicable = last_dot != std::string::npos && (last_dir_pos == std::string::npos || last_dir_pos + 1 < last_dot);  
+
+        if(applicable) {
+            extension = filename.substr(last_dot);
+            std::cout << filename.size() << std::endl;
+            filename  = filename.substr(0,last_dot);
+        }
+
+        std::cout << extension << " " << filename << " " << std::endl;
+
+        oss << filename;
+
+        while(validate_file(oss.str()+extension)) {
+            oss.str("");
+            oss.clear();
+            std::cout << oss.str() << std::endl;
+            oss << filename << "_" << identificator++;
+            std::cout << extension << " " << filename << " " << std::endl;
+        }
+
+        std::cout << oss.str() << std::endl;
+
+        filename = oss.str();
+
+        if(applicable) {
+            filename += extension;
+        }
     }
 
     std::ofstream ofs(filename, std::ios::binary);

--- a/core/source/utils/get_help_message.cpp
+++ b/core/source/utils/get_help_message.cpp
@@ -12,6 +12,7 @@ std::string get_help_message() {
         << "  -t, --time [SECONDS]      Run server for limited time\n"
         << "  -d, --download            Enable only download mode\n"
         << "  -u, --upload              Enable only upload mode\n"
+        << "  -o, --override            Enable override mode\n"
         << "  -D, --dir [DIR]           Set directory to share\n"
         << "  -f, --single-file [FILE]  Share only a specific file\n"
         << "  -r, --recursive           Enable recursive sharing (include subdirectories)\n"


### PR DESCRIPTION
# What does this PR do?

This PR is meant to add a new feature. Before, new file, when uploaded, would override the old file. Now it will happens only if the user sets the flag -o or --override.