### PR TITLE
Add Error message when -D on a directory that does not exist, Fix #12

### DIFF
--- a/core/include/utils.h
+++ b/core/include/utils.h
@@ -7,6 +7,7 @@
 std::string get_local_ip();
 std::string get_help_message();
 bool validate_file(const std::string &file);
+bool validate_directory(const std::string &dir);
 void generate_qr_code(const std::string& url);
 std::string increment_filename(std::string filename);
 

--- a/core/source/parser.cpp
+++ b/core/source/parser.cpp
@@ -29,6 +29,10 @@ void parse_arguments(int argc, char** argv) {
             override_mode = true;
         } else if ((arg == "-D" || arg == "--dir") && i + 1 < argc) {
             shared_directory = argv[++i];
+            if (!validate_file(shared_directory)) {
+                std::cerr << "This directory " + shared_directory + " does not exist!" << std::endl;
+                exit(1);
+            }
         } else if ((arg == "-f" || arg == "--single-file") && i + 1 < argc) {
             single_file = argv[++i];
             if (!validate_file(single_file)) {

--- a/core/source/utils/validate_directory.cpp
+++ b/core/source/utils/validate_directory.cpp
@@ -1,0 +1,8 @@
+#include "../../include/utils.h"
+#include <filesystem>
+
+namespace fs = std::filesystem; 
+
+bool validate_directory(const std::string &dir) {
+    return (fs::exists(dir) && fs::is_directory(dir));
+}


### PR DESCRIPTION
# What does this PR do?

this PR is meant to add Error message when -D on a directory that does not exist, and the user will not be able to share the dir.